### PR TITLE
Resumable Sessions

### DIFF
--- a/bin/pyspark-proxy-server
+++ b/bin/pyspark-proxy-server
@@ -15,7 +15,7 @@ def start(args):
         configure_logging(args.foreground, args.log_level)
 
         if args.foreground:
-            start_server(args.host, args.port)
+            start_server(args)
         else:
             start_background(args)
 
@@ -31,14 +31,14 @@ def start_background(args):
         ## some debug output
         sys.exit(1)
     if pid == 0:
-        start_server(args.host, args.port)
+        start_server(args)
 
-def start_server(host, port):
+def start_server(args):
     import findspark
     findspark.init()
 
     import pyspark_proxy.server as server
-    server.run(host=host, port=port)
+    server.run(host=args.host, port=args.port, resumable=args.resumable)
 
 def load_pid():
     try:
@@ -87,6 +87,7 @@ if __name__ == '__main__':
     parser.add_argument('--host', help='Host to bind to. Default: 0.0.0.0', type=str, default='0.0.0.0')
     parser.add_argument('--foreground', help='Starts server in the foreground', action='store_true')
     parser.add_argument('--log-level', help='Sets logging level. Default: INFO', type=str, default='INFO')
+    parser.add_argument('--resumbable', help='Starts the server with resumable sessions enabled.', action='store_true')
 
     args = parser.parse_args()
 

--- a/pyspark_proxy/proxy.py
+++ b/pyspark_proxy/proxy.py
@@ -29,7 +29,6 @@ class Proxy(object):
     _func_chain = []
 
     def __init__(self, *args, **kwargs):
-        self._id = str(uuid.uuid4())
         self._kwargs = kwargs
         self._class = self.__class__.__name__
         self._args = args
@@ -52,11 +51,13 @@ class Proxy(object):
                 'module': self._module,
                 'class': self._class,
                 'kwargs': kwargs,
-                'args': args,
-                'id': self._id
+                'args': args
                 }
 
         r = requests.post(PROXY_URL+'/create', json=body)
+        res_json = r.json()
+
+        self._id = res_json['id']
 
     # for a single function call
     # ex: df.write.csv('foo.csv')

--- a/pyspark_proxy/server/resumable.py
+++ b/pyspark_proxy/server/resumable.py
@@ -1,0 +1,29 @@
+import hashlib
+import logging
+
+logger = logging.getLogger()
+
+from flask import request
+
+request_responses = {}
+
+def before():
+    global request_responses
+
+    # if RESUMABLE:
+    req_digest = hashlib.sha1(str(request.json)).hexdigest()
+
+    if req_digest in request_responses:
+        logger.info('RESUMABLE: %s - already run, returning result' % req_digest)
+        return request_responses[req_digest]
+    else:
+        logger.info('RESUMABLE: %s - not cached, running' % req_digest)
+
+def after(response):
+    global request_responses
+
+    # if RESUMABLE:
+    req_digest = hashlib.sha1(str(request.json)).hexdigest()
+    request_responses[req_digest] = response
+
+    return response

--- a/pyspark_proxy/server/resumable.py
+++ b/pyspark_proxy/server/resumable.py
@@ -10,7 +10,6 @@ request_responses = {}
 def before():
     global request_responses
 
-    # if RESUMABLE:
     req_digest = hashlib.sha1(str(request.json)).hexdigest()
 
     if req_digest in request_responses:
@@ -22,7 +21,6 @@ def before():
 def after(response):
     global request_responses
 
-    # if RESUMABLE:
     req_digest = hashlib.sha1(str(request.json)).hexdigest()
     request_responses[req_digest] = response
 

--- a/pyspark_proxy/server/server.py
+++ b/pyspark_proxy/server/server.py
@@ -117,8 +117,10 @@ def resumable_before():
         req_digest = hashlib.sha1(str(request.json)).hexdigest()
 
         if req_digest in request_responses:
-            logger.info('%s - already run, returning result' % req_digest)
+            logger.info('RESUMABLE: %s - already run, returning result' % req_digest)
             return request_responses[req_digest]
+        else:
+            logger.info('RESUMABLE: %s - not cached, running' % req_digest)
 
 @app.after_request
 def resumable_after(response):
@@ -139,9 +141,6 @@ def create():
     logger.info('/create')
     logger.info(req)
 
-    req_digest = hashlib.sha1(str(req)).hexdigest()
-    logger.info('%s - has not run' % req_digest)
-
     id = str(uuid.uuid4())
     module_paths = req['module'].split('.')
     base_module = __import__(module_paths[0])
@@ -159,9 +158,6 @@ def create():
     args, kwargs = arg_objects(req['args'], req['kwargs'])
     objects[id] = callable(*args, **kwargs)
 
-    resp = jsonify({'object': True, 'id': id})
-    # request_responses[req_digest] = resp
-    # return resp
     return jsonify({'object': True, 'id': id})
 
 @app.route('/call', methods=['POST'])

--- a/pyspark_proxy/server/server.py
+++ b/pyspark_proxy/server/server.py
@@ -106,7 +106,7 @@ def object_response(obj, exception, paths=[], stdout=[]):
 
 @app.route('/create', methods=['POST'])
 def create():
-    global objects, request_responses
+    global objects
     
     req = request.json
 

--- a/tests/all.py
+++ b/tests/all.py
@@ -12,6 +12,7 @@ from test_functions import FunctionTestCase
 from test_group import GroupTestCase
 from test_rdd import RDDTestCase
 from test_types import TypesTestCase
+from test_resumable_session import ResumableSessionTestCase
 
 if __name__ == '__main__':
     loader = unittest.TestLoader()
@@ -27,7 +28,8 @@ if __name__ == '__main__':
         loader.loadTestsFromTestCase(FunctionTestCase),
         loader.loadTestsFromTestCase(GroupTestCase),
         loader.loadTestsFromTestCase(RDDTestCase),
-        loader.loadTestsFromTestCase(TypesTestCase)
+        loader.loadTestsFromTestCase(TypesTestCase),
+        loader.loadTestsFromTestCase(ResumableSessionTestCase)
     ]
     suite = unittest.TestSuite(tests)
 

--- a/tests/test_resumable_session.py
+++ b/tests/test_resumable_session.py
@@ -1,0 +1,15 @@
+import unittest
+
+from base_test_case import BaseTestCase
+
+from pyspark_proxy import SparkContext
+from pyspark_proxy.sql import SQLContext
+
+class ResumableSessionTestCase(BaseTestCase):
+    def test_resumable_spark_context(self):
+        sc = SparkContext(appName='test_case')
+
+        self.assertEqual(sc._id, self.sc._id)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_resumable_session.py
+++ b/tests/test_resumable_session.py
@@ -1,15 +1,45 @@
+from multiprocessing import Process
 import unittest
+import requests
 
 from base_test_case import BaseTestCase
 
 from pyspark_proxy import SparkContext
 from pyspark_proxy.sql import SQLContext
 
-class ResumableSessionTestCase(BaseTestCase):
+import pyspark_proxy.server as server
+
+class ResumableSessionTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Process(target=server.run, kwargs={'resumable': True, 'debug': True, 'use_reloader': False})
+        cls.server.start()
+        cls.server.join(1) # needs some time to boot up the webserver
+
+        cls.sc = SparkContext(appName='test_case')
+        cls.sc.setLogLevel('ERROR')
+        cls.sqlContext = SQLContext(cls.sc)
+
+    @classmethod
+    def tearDownClass(self):
+        requests.get('http://localhost:8765/clear')
+
+        self.server.terminate()
+
     def test_resumable_spark_context(self):
         sc = SparkContext(appName='test_case')
 
         self.assertEqual(sc._id, self.sc._id)
+
+    def test_resumable_create_dataframe(self):
+        data = [(1,2,'a'),(3,4,'b'),(5,6,'c')]
+
+        df1 = self.sqlContext.createDataFrame(data, ['foo', 'bar', 'baz'])
+        df2 = self.sqlContext.createDataFrame(data, ['foo', 'bar', 'baz'])
+        df3 = self.sqlContext.createDataFrame(data, ['a', 'b', 'c'])
+
+        self.assertEqual(df1._id, df2._id)
+        self.assertNotEqual(df2._id, df3._id)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Resumable Sessions
Resumable sessions is a configurable option that allows the same code to be run client side without re-computing things server side. Only the new code that you produce that hasn't run yet will actually get executed in Spark. This allows you to get a notebook style computation environment in a regular python file.

Lets say we have this simple spark application `example.py`:
```python
sc = SparkContext(appName='demo')
sqlContext = SQLContext(sc)

df = sqlContext.read.json('data.json')
print(df.count())
```
When this runs each line of code will get executed.

Now lets say we're actively developing it and changing code around to where `example.py` now looks like this:

```python
sc = SparkContext(appName='demo')
sqlContext = SQLContext(sc)

df = sqlContext.read.json('data.json')
print(df.count())

filtered_df = df.filter(df.foo == 1)

filtered.show()
```

When this gets run, only the new lines actually get executed on the server:
```python
sc = SparkContext(appName='demo')    # not run
sqlContext = SQLContext(sc)          # not run

df = sqlContext.read.json('data.json') # not run
print(df.count())                      # not run

filtered_df = df.filter(df.foo == 1)   # new code, runs

filtered.show()                        # new code, runs
```

### Enabling
Resumable sessions are disabled by default. To enable just specify the `--resumable` parameter when starting pyspark proxy.

Ex: `pyspark-proxy-server start --resumable`
